### PR TITLE
OPS-2149 catch and log errors when region auth fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ update-ec2-tags.py
 Updates instance tag in ec2, with puppet classes.
 
 
+When code is pushed to master, a Jenkins job should automatically build, package, and upload the new version. See: http://ci.krxd.net/job/aws-analysis-tools/

--- a/aws_analysis_tools/ec2_events.py
+++ b/aws_analysis_tools/ec2_events.py
@@ -30,6 +30,7 @@ import krux_boto
 ### Third Party Libraries ###
 #############################
 
+import boto.exception
 import flowdock
 
 
@@ -75,10 +76,14 @@ class Application(krux_boto.Application):
         for r in ec2.get_all_regions():
 
             log.debug('Checking region: %s', r.name)
-            conn = self.boto.connect_ec2(region = r)
+            try:
+                conn = self.boto.connect_ec2(region = r)
 
-            ### Get the status of all instances
-            all_status = conn.get_all_instance_status()
+                ### Get the status of all instances
+                all_status = conn.get_all_instance_status()
+            except boto.exception.EC2ResponseError, e:
+                log.error('Unable to query region %r due to %r', r.name, e)
+                continue
             for status in all_status:
 
                 ### are there events?

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from pip.req    import parse_requirements
 import os
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION      = '0.0.8'
+VERSION      = '0.0.9'
 
 # URL to the repository on Github.
 REPO_URL     = 'https://github.com/krux/aws-analysis-tools'


### PR DESCRIPTION
When looping through regions, one or more may have auth issues due to it being new/down/etc. Log those errors and continue.