### PR TITLE
Use consistent ordering for search results.

### DIFF
--- a/aws_analysis_tools/cli/search_ec2_tags.py
+++ b/aws_analysis_tools/cli/search_ec2_tags.py
@@ -147,7 +147,7 @@ def search_tags(query_terms, passed_regions=None, log=None):
             continue
 
 
-    return inst_names
+    return sorted(inst_names)
 
 
 class Application(krux.cli.Application):


### PR DESCRIPTION
Before:

    <aws-analysis-tools> (=31315) plathrop@bolt s002 aws-analysis-tools➔ krux-search-ec2-tags -f unix 's_classes:s_fastlane'
    fastlane-a003.krxd.net
    fastlane-a006.krxd.net
    fastlane-a004.krxd.net
    plathrop-fastlane-data-dev001.krxd.net
    fastlane-a005.krxd.net
    fastlane-a001.krxd.net
    fastlane-a002.krxd.net

After:

     <aws-analysis-tools> (=31315) plathrop@bolt s002 aws-analysis-tools➔ krux-search-ec2-tags -f unix 's_classes:s_fastlane' | tee ~/tmp/v2.txt
	fastlane-a001.krxd.net
	fastlane-a002.krxd.net
	fastlane-a003.krxd.net
	fastlane-a004.krxd.net
	fastlane-a005.krxd.net
	fastlane-a006.krxd.net
	plathrop-fastlane-data-dev001.krxd.net