### PR TITLE
Fixed run() to call output_table instead of output_table_to_file

### DIFF
--- a/aws_analysis_tools/cli/instances.py
+++ b/aws_analysis_tools/cli/instances.py
@@ -130,10 +130,11 @@ class Application(krux_ec2.cli.Application):
             help="Exclude instances with these states (regex)",
         )
 
-    """
-    Convert options dictionary to use AWS filters as keys instead of CLI options.
-    """
     def convert_args(self):
+        """
+        Convert options dictionary to use AWS filters as keys instead of CLI options.
+        """
+
         # Dictionary of options and values to put in the Filter
         filter_dict = {}
 
@@ -146,11 +147,10 @@ class Application(krux_ec2.cli.Application):
 
         return filter_dict
 
-    """
-    Use filter_dict to filter instances based on inclusion/exclusion options
-    """
     def filter_args(self, filter_dict):
-
+        """
+        Use filter_dict to filter instances based on inclusion/exclusion options
+        """
         f = Filter(filter_dict)
 
         # Filter/find instances based on inclusion filters
@@ -173,10 +173,10 @@ class Application(krux_ec2.cli.Application):
 
         return instances
 
-    """
-    Outputs filtered instances as a table
-    """
     def output_table(self, instances):
+        """
+        Outputs filtered instances as a table
+        """
         table       = Texttable( max_width=0 )
 
         table.set_deco( Texttable.HEADER )

--- a/aws_analysis_tools/cli/instances.py
+++ b/aws_analysis_tools/cli/instances.py
@@ -211,7 +211,7 @@ class Application(krux_ec2.cli.Application):
     def run(self):
         filter_dict = self.convert_args()
         instances = self.filter_args(filter_dict)
-        self.output_table_to_file(instances)
+        self.output_table(instances)
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION      = '0.4.2'
+VERSION      = '0.4.3'
 
 # URL to the repository on Github.
 REPO_URL     = 'https://github.com/krux/aws-analysis-tools'


### PR DESCRIPTION
Call output_table on instances to print to terminal instead of output_table_to_file (method that no longer exists). 