### PR TITLE
Create krux-ec2-ip script to convert IP address to hostname

### DIFF
--- a/aws_analysis_tools/cli/convert_ip.py
+++ b/aws_analysis_tools/cli/convert_ip.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+#
+# © 2016 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+from pprint import pformat
+
+#
+# Internal libraries
+#
+
+import krux_ec2.cli
+from krux_ec2.filter import Filter
+
+NAME = 'convert_ip'
+
+
+class Application(krux_ec2.cli.Application):
+
+    _IP = 'ip-address'
+    _PRIVATE_IP = 'private-ip-address'
+
+    def __init__(self, name=NAME):
+        # Call to the superclass to bootstrap.
+        super(Application, self).__init__(name=name)
+
+        self.filter_arg = Application._PRIVATE_IP if self.args.private else Application._IP
+
+    def add_cli_arguments(self, parser):
+        # Call to the superclass first
+        super(Application, self).add_cli_arguments(parser)
+
+        parser.set_defaults(log_level='info')
+
+        group = krux_ec2.cli.get_group(parser, self.name)
+
+        group.add_argument(
+            "ip_address",
+            help="IP address to be converted",
+        )
+
+        group.add_argument(
+            "-p", "--private",
+            action='store_true',
+            default=False,
+            help="True if the given IP address is private. Default: %(default)s",
+        )
+
+    def find_instance(self, filter_arg, address):
+        f = Filter()
+        f.add_filter(
+            name=filter_arg,
+            value=address
+        )
+        return self.ec2.find_instances(f)
+
+    def output_info(self, instances, filter_arg, address):
+        if len(instances) != 0:
+            i = instances[0]
+            ip_info = {
+                'Instance Name': str(i.tags.get('Name', '')),
+                'IP Address': str(i.ip_address),
+                'Private IP Address': str(i.private_ip_address),
+                'DNS Name': str(i.dns_name),
+            }
+            self.logger.info('\n' + pformat(ip_info))
+
+        else:
+            self.logger.error('No instance with ' + filter_arg + ': ' + address + ' was found.')
+
+    def run(self):
+        instances = self.find_instance(self.filter_arg, self.args.ip_address)
+        self.output_info(instances, self.filter_arg, self.args.ip_address)
+
+def main():
+    app = Application()
+    app.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/aws_analysis_tools/cli/convert_ip.py
+++ b/aws_analysis_tools/cli/convert_ip.py
@@ -79,7 +79,7 @@ class Application(krux_ec2.cli.Application):
                 self.logger.info('\n' + pformat(ip_info))
 
         else:
-            self.logger.error('No instance with ' + filter_arg + ': ' + address + ' was found.')
+            self.logger.info('No instance with ' + filter_arg + ': ' + address + ' was found.')
 
     def run(self):
         instances = self.find_instances(self.filter_arg, self.args.ip_address)

--- a/aws_analysis_tools/cli/convert_ip.py
+++ b/aws_analysis_tools/cli/convert_ip.py
@@ -52,7 +52,7 @@ class Application(krux_ec2.cli.Application):
             help="True if the given IP address is private. (default: %(default)s)",
         )
 
-    def find_instance(self, filter_arg, address):
+    def find_instances(self, filter_arg, address):
         """
         Searches for AWS instance based on given filter argument and ip address (private or normal).
         """
@@ -82,8 +82,9 @@ class Application(krux_ec2.cli.Application):
             self.logger.error('No instance with ' + filter_arg + ': ' + address + ' was found.')
 
     def run(self):
-        instances = self.find_instance(self.filter_arg, self.args.ip_address)
+        instances = self.find_instances(self.filter_arg, self.args.ip_address)
         self.output_info(instances, self.filter_arg, self.args.ip_address)
+
 
 def main():
     app = Application()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION      = '0.4.5'
+VERSION      = '0.5.0'
 
 # URL to the repository on Github.
 REPO_URL     = 'https://github.com/krux/aws-analysis-tools'
@@ -44,6 +44,7 @@ setup(
             'krux-ec2-pssh2          = aws_analysis_tools.cli.pssh2:main',
             'krux-ec2-events         = aws_analysis_tools.ec2_events.cli:main',
             'krux-ec2-test-provision = aws_analysis_tools.cli.test_provision:main',
+            'krux-ec2-ip             = aws_analysis_tools.cli.convert_ip:main',
         ],
     },
 )

--- a/test/cli/convert_ip_test.py
+++ b/test/cli/convert_ip_test.py
@@ -87,15 +87,15 @@ class ConvertIPtest(unittest.TestCase):
         i.private_ip_address = self.IP_ADDRESS
         i.dns_name = self.INSTANCE_DNS
 
-        self.app.output_info([i], self.IP, self.IP_ADDRESS)
+        self.app.output_info([i, i, i], self.IP, self.IP_ADDRESS)
         ip_info = {
             'Instance Name': str(i.tags.get('Name', '')),
             'IP Address': str(i.ip_address),
             'Private IP Address': str(i.private_ip_address),
             'DNS Name': str(i.dns_name),
         }
-        self.app.logger.info.assert_called_once_with('\n'+ pformat(ip_info))
-
+        self.app.logger.info.assert_called_with('\n'+ pformat(ip_info))
+        self.assertEqual(self.app.logger.info.call_count, 3)
 
     def test_output_info_no_instances(self):
         """

--- a/test/cli/convert_ip_test.py
+++ b/test/cli/convert_ip_test.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+#
+# © 2016 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+import unittest
+import sys
+
+#
+# Third party libraries
+#
+
+from mock import MagicMock, patch
+
+#
+# Internal libraries
+#
+
+from aws_analysis_tools.cli.convert_ip import Application, NAME, main
+from krux.stats import DummyStatsClient
+
+class ConvertIPtest(unittest.TestCase):
+
+    def setUp(self):
+        self.app = Application()
+
+    def test_init_(self):
+        """
+        Application is only created with the checker when no CLI arguments are passed
+        """
+        self.app.args.private = None
+
+        # There are not much we can test except all the objects are under the correct name
+        self.assertEqual(NAME, self.app.name)
+        self.assertEqual(NAME, self.app.parser.description)
+        # The dummy stats client has no awareness of the name. Just check the class.
+        self.assertIsInstance(self.app.stats, DummyStatsClient)
+        self.assertEqual(NAME, self.app.logger.name)
+
+        self.assertEqual(self.app.filter_arg, self._IP)
+
+    # @patch.object(sys, 'argv', ['prog', '--jira-username', JIRA_USERNAME, '--jira-password', JIRA_PASSWORD, '--jira-base-url', JIRA_BASE_URL, '--flowdock-token', FLOW_TOKEN, '--urgent', FLOW_URGENT])
+    # @patch('aws_analysis_tools.ec2_events.cli.EC2EventChecker')
+    # @patch('aws_analysis_tools.ec2_events.cli.FlowdockListener')
+    # @patch('aws_analysis_tools.ec2_events.cli.JiraListener')
+    # def test_init_all_set(self, mock_jira, mock_flowdock, mock_checker):
+    #     """
+    #     Flowdock and JIRA listeners are created correctly when all CLI arguments are passed
+    #     """
+    #     app = Application()
+
+    #     mock_checker.assert_called_once_with(
+    #         boto=app.boto,
+    #         name=NAME,
+    #         logger=app.logger,
+    #         stats=app.stats
+    #     )
+    #     mock_flowdock.assert_called_once_with(
+    #         flow_token=self.FLOW_TOKEN,
+    #         name=NAME,
+    #         logger=app.logger,
+    #         stats=app.stats
+    #     )
+    #     self.assertEqual(mock_flowdock.return_value.urgent_threshold, int(self.FLOW_URGENT))
+    #     mock_jira.assert_called_once_with(
+    #         username=self.JIRA_USERNAME,
+    #         password=self.JIRA_PASSWORD,
+    #         base_url=self.JIRA_BASE_URL,
+    #         name=NAME,
+    #         logger=app.logger,
+    #         stats=app.stats
+    #     )
+
+    # def test_add_cli_arguments(self):
+    #     """
+    #     All arguments from the checkers and listeners are present in the args
+    #     """
+    #     app = Application()
+
+    #     self.assertIn('flowdock_token', app.args)
+    #     self.assertIn('jira_username', app.args)
+    #     self.assertIn('jira_password', app.args)
+    #     self.assertIn('jira_base_url', app.args)
+
+    # def test_run(self):
+    #     """
+    #     Checker's check() method is correctly called in app.run()
+    #     """
+    #     checker = MagicMock()
+
+    #     with patch('aws_analysis_tools.ec2_events.cli.EC2EventChecker', return_value=checker):
+    #         app = Application()
+    #         app.run()
+
+    #     checker.check.assert_called_once_with()
+
+    # def test_main(self):
+    #     """
+    #     Application is instantiated and run() is called in main()
+    #     """
+    #     app = MagicMock()
+    #     app_class = MagicMock(return_value=app)
+
+    #     with patch('aws_analysis_tools.ec2_events.cli.Application', app_class):
+    #         main()
+
+    #     app_class.assert_called_once_with()
+    #     app.run.assert_called_once_with()

--- a/test/cli/convert_ip_test.py
+++ b/test/cli/convert_ip_test.py
@@ -114,7 +114,7 @@ class ConvertIPtest(unittest.TestCase):
         self.app.output_info([], self.IP, self.IP_ADDRESS)
 
         msg = 'No instance with {0}: {1} was found.'.format(self.IP, self.IP_ADDRESS)
-        self.app.logger.error.assert_called_once_with(msg)
+        self.app.logger.info.assert_called_once_with(msg)
 
 
     def test_add_cli_arguments(self):


### PR DESCRIPTION
Searches for instances based on either ip address or private ip address. Given a list of instances, prints out each instance's name, IP address, private IP address, and DNS name in a dictionary. PE-2104