### PR TITLE
--os

### DIFF
--- a/aws_analysis_tools/cli/update_ec2_tags.py
+++ b/aws_analysis_tools/cli/update_ec2_tags.py
@@ -77,7 +77,7 @@ class Application(krux_boto.Application):
             # Let's make sure to tag this for now
             # TODO: Pull out the code to deduce this from krux-manage-instance and use it here.
             required=True,
-            help=("The name of the ubuntu release to set. Example: Trusty"),
+            help=("The name of the ubuntu release to set. Example: 'trusty'"),
         )
 
         group.add_argument(

--- a/aws_analysis_tools/cli/update_ec2_tags.py
+++ b/aws_analysis_tools/cli/update_ec2_tags.py
@@ -33,6 +33,7 @@ class Application(krux_boto.Application):
         self.environment = self.args.environment
         self.cluster_name = self.args.cluster_name
         self.classes = self.args.classes
+        self.os = self.args.os
         self.dry_run = self.args.dry_run
 
     def add_cli_arguments(self, parser):
@@ -75,6 +76,12 @@ class Application(krux_boto.Application):
         )
 
         group.add_argument(
+            '--os',
+            default=None,
+            help=("The name of the OS to set. Example: Trusty"),
+        )
+
+        group.add_argument(
             '--dry-run',
             default=False,
             action='store_true',
@@ -89,6 +96,7 @@ class Application(krux_boto.Application):
         classes=None,
         environment=None,
         cluster_name=None,
+        os=None,
         dry_run=False,
     ):
         log = self.logger
@@ -100,6 +108,7 @@ class Application(krux_boto.Application):
         classes = classes if classes is not None else self.classes
         dry_run = dry_run if dry_run is not None else self.dry_run
         environment = environment if environment is not None else self.environment
+        os = os if os is not None else self.os
         cluster_name = cluster_name if cluster_name is not None else self.cluster_name
 
         with stats.timing('update_tags'):
@@ -124,6 +133,7 @@ class Application(krux_boto.Application):
                 'environment': environment,
                 'cluster_name': cluster_name,
                 EC2_CLASS_KEY: ",".join(classes),
+                'os': os,
             }
 
             # quick dump of what we're about to do send.

--- a/aws_analysis_tools/cli/update_ec2_tags.py
+++ b/aws_analysis_tools/cli/update_ec2_tags.py
@@ -111,10 +111,12 @@ class Application(krux_boto.Application):
         with stats.timing('update_tags'):
 
             # without region or instance id, we can't proceed
-            if not ec2_region or not instance_id:
+            if ec2_region is None or instance_id is None:
                 self.raise_critical_error(
-                    'Could not determine instance_id (%s) and/or ec2_region (%s)' %
-                    (instance_id, ec2_region)
+                    'Could not determine instance_id ({instance_id}) and/or ec2_region ({region})'.format(
+                        instance_id=instance_id,
+                        region=ec2_region,
+                    )
                 )
 
             # many places the info can come from, so let us know here what we found

--- a/aws_analysis_tools/cli/update_ec2_tags.py
+++ b/aws_analysis_tools/cli/update_ec2_tags.py
@@ -95,12 +95,12 @@ class Application(krux_boto.Application):
         stats = self.stats
 
         # from cli or passed explicitly?
-        ec2_region = ec2_region or self.ec2_region
-        instance_id = instance_id or self.instance_id
-        classes = classes or self.classes
-        dry_run = dry_run or self.dry_run
-        environment = environment or self.environment
-        cluster_name = cluster_name or self.cluster_name
+        ec2_region = ec2_region if ec2_region is not None else self.ec2_region
+        instance_id = instance_id if instance_id is not None else self.instance_id
+        classes = classes if classes is not None else self.classes
+        dry_run = dry_run if dry_run is not None else self.dry_run
+        environment = environment if environment is not None else self.environment
+        cluster_name = cluster_name if cluster_name is not None else self.cluster_name
 
         with stats.timing('update_tags'):
 

--- a/aws_analysis_tools/cli/update_ec2_tags.py
+++ b/aws_analysis_tools/cli/update_ec2_tags.py
@@ -19,9 +19,6 @@ import krux_boto
 from krux_boto import add_boto_cli_arguments
 
 
-EC2_CLASS_KEY = 's_classes'
-
-
 class Application(krux_boto.Application):
 
     def __init__(self):
@@ -132,7 +129,7 @@ class Application(krux_boto.Application):
             tags_dict = {
                 'environment': environment,
                 'cluster_name': cluster_name,
-                EC2_CLASS_KEY: ",".join(classes),
+                's_classes': ",".join(classes),
                 'os': os,
             }
 

--- a/aws_analysis_tools/cli/update_ec2_tags.py
+++ b/aws_analysis_tools/cli/update_ec2_tags.py
@@ -30,7 +30,7 @@ class Application(krux_boto.Application):
         self.environment = self.args.environment
         self.cluster_name = self.args.cluster_name
         self.classes = self.args.classes
-        self.os = self.args.os
+        self.release = self.args.release
         self.dry_run = self.args.dry_run
 
     def add_cli_arguments(self, parser):
@@ -73,9 +73,11 @@ class Application(krux_boto.Application):
         )
 
         group.add_argument(
-            '--os',
-            default=None,
-            help=("The name of the OS to set. Example: Trusty"),
+            '--release',
+            # Let's make sure to tag this for now
+            # TODO: Pull out the code to deduce this from krux-manage-instance and use it here.
+            required=True,
+            help=("The name of the ubuntu release to set. Example: Trusty"),
         )
 
         group.add_argument(
@@ -93,7 +95,7 @@ class Application(krux_boto.Application):
         classes=None,
         environment=None,
         cluster_name=None,
-        os=None,
+        release=None,
         dry_run=False,
     ):
         log = self.logger
@@ -105,7 +107,7 @@ class Application(krux_boto.Application):
         classes = classes if classes is not None else self.classes
         dry_run = dry_run if dry_run is not None else self.dry_run
         environment = environment if environment is not None else self.environment
-        os = os if os is not None else self.os
+        release = release if release is not None else self.release
         cluster_name = cluster_name if cluster_name is not None else self.cluster_name
 
         with stats.timing('update_tags'):
@@ -132,7 +134,7 @@ class Application(krux_boto.Application):
                 'environment': environment,
                 'cluster_name': cluster_name,
                 's_classes': ",".join(classes),
-                'os': os,
+                'release': release,
             }
 
             # quick dump of what we're about to do send.

--- a/aws_analysis_tools/cli/update_ec2_tags.py
+++ b/aws_analysis_tools/cli/update_ec2_tags.py
@@ -117,7 +117,9 @@ class Application(krux_boto.Application):
                 instance_id, ec2_region, ' '.join(classes)
             )
 
+            #
             # Set up the tags we want to use
+            #
             tags_dict = {
                 'environment': environment,
                 'cluster_name': cluster_name,
@@ -147,14 +149,15 @@ class Application(krux_boto.Application):
 
                 # no matter what happens, we want to catch it and make sure
                 # log it appropriately before we re-raise
-                except Exception, e:
+                except Exception:
                     stats.incr('error.ec2_tag_update')
-                    self.raise_critical_error('Tag update failed: %s' % e)
+                    raise
 
 
 def main():
     app = Application()
-    app.update_tags()
+    with app.context():
+        app.update_tags()
 
 
 if __name__ == '__main__':

--- a/aws_analysis_tools/cli/update_ec2_tags.py
+++ b/aws_analysis_tools/cli/update_ec2_tags.py
@@ -25,15 +25,15 @@ EC2_CLASS_KEY = 's_classes'
 class Application(krux_boto.Application):
 
     def __init__(self):
-        ### Call superclass to get krux-stdlib
-        super(Application, self).__init__(name = 'update-ec2-tags')
+        # Call superclass to get krux-stdlib
+        super(Application, self).__init__(name='update-ec2-tags')
 
-        self.instance_id    = self.args.instance_id
-        self.ec2_region     = self.args.ec2_region
-        self.environment    = self.args.environment
-        self.cluster_name   = self.args.cluster_name
-        self.classes        = self.args.classes
-        self.dry_run        = self.args.dry_run
+        self.instance_id = self.args.instance_id
+        self.ec2_region = self.args.ec2_region
+        self.environment = self.args.environment
+        self.cluster_name = self.args.cluster_name
+        self.classes = self.args.classes
+        self.dry_run = self.args.dry_run
 
     def add_cli_arguments(self, parser):
 
@@ -43,116 +43,114 @@ class Application(krux_boto.Application):
 
         group.add_argument(
             '--instance-id',
-            help = "The instance id of the instance. Example: 'i-27459bcc' "
-            "(output of `facter ec2_instance_id`)"
+            help=("The instance id of the instance. Example: 'i-27459bcc' "
+                  "(output of `facter ec2_instance_id`)")
         )
 
         group.add_argument(
             '--ec2-region',
-            required = True,
-            help     = "EC2 region to use. Example: 'us-east-1'. "
-            "NB: This is the *region*, not the *availability zone*."
+            required=True,
+            help=("EC2 region to use. Example: 'us-east-1'. "
+                  "NB: This is the *region*, not the *availability zone*.")
         )
 
         group.add_argument(
             '--environment',
-            default = 'dev',
-            help    = "The environment to set. (default: %(default)s)."
+            default='dev',
+            help="The environment to set. (default: %(default)s)."
         )
 
         group.add_argument(
             '--cluster-name',
-            required = True,
-            help     = "The cluster name to set. Example: 'apiservices-a'"
+            required=True,
+            help="The cluster name to set. Example: 'apiservices-a'"
         )
 
         group.add_argument(
             '--classes',
-            nargs   = "*",
-            default = [],
-            help    = "Specify class to tag with (can be used multiple times). "
-            "(default: %(default)s)"
+            nargs="*",
+            default=[],
+            help=("Specify class to tag with (can be used multiple times). "
+                  "(default: %(default)s)")
         )
 
         group.add_argument(
             '--dry-run',
-            default = False,
-            action  = 'store_true',
-            help    = "Do a dry run; find the tags, but do not update them "
-            "in EC2. (default: %(default)s)"
+            default=False,
+            action='store_true',
+            help=("Do a dry run; find the tags, but do not update them "
+                  "in EC2. (default: %(default)s)")
         )
 
-    def update_tags(self,
-        ec2_region      = None,
-        instance_id     = None,
-        classes         = None,
-        environment     = None,
-        cluster_name    = None,
-        dry_run         = False,
+    def update_tags(
+        self,
+        ec2_region=None,
+        instance_id=None,
+        classes=None,
+        environment=None,
+        cluster_name=None,
+        dry_run=False,
     ):
-        log   = self.logger
+        log = self.logger
         stats = self.stats
 
-        ### from cli or passed explicitly?
-        ec2_region      = ec2_region    or self.ec2_region
-        instance_id     = instance_id   or self.instance_id
-        classes         = classes       or self.classes
-        dry_run         = dry_run       or self.dry_run
-        environment     = environment   or self.environment
-        cluster_name    = cluster_name  or self.cluster_name
-
+        # from cli or passed explicitly?
+        ec2_region = ec2_region or self.ec2_region
+        instance_id = instance_id or self.instance_id
+        classes = classes or self.classes
+        dry_run = dry_run or self.dry_run
+        environment = environment or self.environment
+        cluster_name = cluster_name or self.cluster_name
 
         with stats.timing('update_tags'):
 
-            ### without region or instance id, we can't proceed
+            # without region or instance id, we can't proceed
             if not ec2_region or not instance_id:
                 self.raise_critical_error(
-                    'Could not determine instance_id (%s) and/or ec2_region (%s)' % \
+                    'Could not determine instance_id (%s) and/or ec2_region (%s)' %
                     (instance_id, ec2_region)
                 )
 
-            ### many places the info can come from, so let us know here what we found
+            # many places the info can come from, so let us know here what we found
             log.info(
                 'Proceeding with instance id: %s - region: %s - classes: %s',
                 instance_id, ec2_region, ' '.join(classes)
             )
 
-            ###
-            ### Set up the tags we want to use
-            ###
+            # Set up the tags we want to use
             tags_dict = {
-                'environment':  environment,
+                'environment': environment,
                 'cluster_name': cluster_name,
-                EC2_CLASS_KEY:  ",".join(classes),
+                EC2_CLASS_KEY: ",".join(classes),
             }
 
-            ### quick dump of what we're about to do send.
-            for k,v in tags_dict.iteritems():
+            # quick dump of what we're about to do send.
+            for k, v in tags_dict.iteritems():
                 log.info('Setting tag "%s" to: %s', k, v)
 
-
-            ###
-            ### Now do the actual update, if desired
-            ###
+            #
+            # Now do the actual update, if desired
+            #
             if dry_run:
                 log.info('Dry run - not updating instance in EC2')
 
             else:
                 log.info('Updating instance %s in region %s', instance_id, ec2_region)
-                region_obj  = self.boto.ec2.get_region(ec2_region)
-                ec2         = self.boto.connect_ec2(region = region_obj)
+                region_obj = self.boto.ec2.get_region(ec2_region)
+                ec2 = self.boto.connect_ec2(region=region_obj)
 
-                ### ec2 calls throw exceptions when they fail
+                # ec2 calls throw exceptions when they fail
                 try:
                     ec2.create_tags([instance_id], tags_dict)
                     stats.incr('ec2_tag_update')
                     log.info('Update completed successfully')
 
-                ### no matter what happens, we want to catch it and make sure
-                ### log it appropriately before we re-raise
+                # no matter what happens, we want to catch it and make sure
+                # log it appropriately before we re-raise
                 except Exception, e:
                     stats.incr('error.ec2_tag_update')
                     self.raise_critical_error('Tag update failed: %s' % e)
+
 
 def main():
     app = Application()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION      = '0.5.0'
+VERSION      = '0.6.0'
 
 # URL to the repository on Github.
 REPO_URL     = 'https://github.com/krux/aws-analysis-tools'


### PR DESCRIPTION
## What does this PR do?
This PR adds an CLI option to tag the instance with the OS code name.

## Why is this change being made?
It is rather painful process to find out which version of Ubuntu the instance is running via backward search through AMI ID. Let's just tag the instance.

## Where should the reviewer start?
`aws_analysis_tools/cli/update_ec2_tags.py`

## How was this tested? How can the reviewer verify your testing?
This was tested manually in development environment using `phan-dev-pdx-a002.krxd.net`

## Completion checklist

- [x] The pull request has been appropriately labelled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [x] Documentation has been updated.