### PR TITLE
Add kernel_version to AWS tags

### DIFF
--- a/aws_analysis_tools/cli/update_ec2_tags.py
+++ b/aws_analysis_tools/cli/update_ec2_tags.py
@@ -9,6 +9,7 @@ AWS imposes on tags, and emits stats via krux.cli fanciness.
 # Standard Libraries #
 ######################
 from __future__ import absolute_import
+import platform
 
 ##################
 # Krux Libraries #
@@ -32,6 +33,7 @@ class Application(krux_boto.Application):
         self.classes = self.args.classes
         self.lts = self.args.lts
         self.architecture = self.args.architecture
+        self.kernel_version = self.args.kernel_version
         self.dry_run = self.args.dry_run
 
     def add_cli_arguments(self, parser):
@@ -88,6 +90,12 @@ class Application(krux_boto.Application):
         )
 
         group.add_argument(
+            '--kernel-version',
+            help=("The kernel version of this instance to set. Example: '3.13.0-137-generic' "
+                  "(default: `uname -r`)")
+        )
+
+        group.add_argument(
             '--dry-run',
             default=False,
             action='store_true',
@@ -104,6 +112,7 @@ class Application(krux_boto.Application):
         cluster_name=None,
         lts=None,
         architecture=None,
+        kernel_version=None,
         dry_run=False,
     ):
         log = self.logger
@@ -118,6 +127,7 @@ class Application(krux_boto.Application):
         cluster_name = cluster_name if cluster_name is not None else self.cluster_name
         lts = lts if lts is not None else self.lts
         architecture = architecture if architecture is not None else self.architecture
+        kernel_version = kernel_version or self.kernel_version or platform.release()
 
         with stats.timing('update_tags'):
 
@@ -145,6 +155,7 @@ class Application(krux_boto.Application):
                 's_classes': ",".join(classes),
                 'lts': lts,
                 'architecture': architecture,
+                'kernel_version': kernel_version,
             }
 
             # quick dump of what we're about to do send.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # © 2014 Krux Digital, Inc.
+# © 2018 Salesforce.com, Inc.
 #
 """
 Package setup for aws-analysis-tools
@@ -12,7 +13,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION      = '0.6.1'
+VERSION      = '0.6.2'
 
 # URL to the repository on Github.
 REPO_URL     = 'https://github.com/krux/aws-analysis-tools'


### PR DESCRIPTION
## What does this PR do?

This PR adds "--kernel-version" to the options for AWS tags, and by default, uses the value of the running kernel (same as "uname -r"). A specific value can also be specified.

## Why is this change being made?

We want to be able to track kernel updates across the fleet, and this tag will help find differing members.

## How was this tested? How can the reviewer verify your testing?

A dev instance was used to run various options and values, and to verify that they are reflected in AWS.

## What are your deployment and rollback plans?

This will get merged, and then need to be built. The puppet module "kaws" specifies the package by exact version, so it can be changed at will.

## What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/d5Z7OhCs6y2K4/giphy.gif)