### PR TITLE
PE-6426: Bug fix

### DIFF
--- a/aws_analysis_tools/cli/instances.py
+++ b/aws_analysis_tools/cli/instances.py
@@ -237,7 +237,7 @@ class Application(krux_ec2.cli.Application):
                 i.tags.get('Name', ' '),
                 i.instance_type,
                 i._placement,
-                i.groups[0].name,
+                i.groups[0].name if len(i.groups) > 0 else None,
                 i.state,
                 i.root_device_type,
                 volumes or '-'

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION      = '0.6.2'
+VERSION      = '0.6.3'
 
 # URL to the repository on Github.
 REPO_URL     = 'https://github.com/krux/aws-analysis-tools'


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug where the `krux-ec2-instance` script fails when it tries to display a terminated, but visible instance.

## Why is this change being made?

This is a bug fix.

## How does this PR do it?

`i.groups` is a list of security groups. If an instance is terminated, this list is empty. `i.groups[0]` causes a `KeyError`. 

## How was this tested? How can the reviewer verify your testing?

The change was tested on the local development environment.

```bash
$ krux-ec2-instances -G Elastic -G krux-periodic -G nat-erin --no-name -H --boto-region us-east-1
Traceback (most recent call last):
  File "/Users/phan/.virtualenvs/aws-analysis-tools-X-8mCMP0/bin/krux-ec2-instances", line 11, in <module>
    load_entry_point('aws-analysis-tools', 'console_scripts', 'krux-ec2-instances')()
  File "/Users/phan/projects/aws-analysis-tools/aws_analysis_tools/cli/instances.py", line 262, in main
    app.run()
  File "/Users/phan/projects/aws-analysis-tools/aws_analysis_tools/cli/instances.py", line 256, in run
    self.output_table(instances)
  File "/Users/phan/projects/aws-analysis-tools/aws_analysis_tools/cli/instances.py", line 241, in output_table
    i.groups[0].name,
IndexError: list index out of range
$ krux-ec2-instances -G Elastic -G krux-periodic -G nat-erin --no-name -H --boto-region us-east-1
i-0b6b1d818c1697458       c3.8xlarge   us-east-1a   None   terminated   ebs   -
i-068bce60f7fb15cff       c3.4xlarge   us-east-1a   None   terminated   ebs   -
i-08b1b635e06a648b5       c3.4xlarge   us-east-1a   None   terminated   ebs   -
i-05d3a61711836819f       c3.4xlarge   us-east-1a   None   terminated   ebs   -
i-07575d2dfaf9c639f       c3.4xlarge   us-east-1a   None   terminated   ebs   -
```

## What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/xT5LMKgAu0SqZ4BUSk/giphy.gif)

## Completion checklist

- [x] The pull request has been appropriately labeled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review).
- [x] The version of the package has been updated according to [Semantic Versioning](http://semver.org/).
- [x] The change has unit & integration tests as appropriate.
- [x] Documentation is up to date and correct.
- [x] Dependencies are correctly listed under `requirements.pip` and
      are up to date without going over a major version.
- [x] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.
- [x] The change is either small or have been canaried in the appropriate environment(s).