### PR TITLE
W-7089157 deal with NoneType exception for terminated instances

### DIFF
--- a/aws_analysis_tools/cli/instances.py
+++ b/aws_analysis_tools/cli/instances.py
@@ -183,7 +183,12 @@ class Application(krux_ec2.cli.Application):
                 'Excluding instances from the list of %s instances based on filter (%s)',
                 len(instances), 'no_name'
             )
-            instances = [i for i in instances if 'Name' not in i.tags]
+            filtered = []
+            for i in instances:
+                if i.tags and not [tag for tag in i.tags
+                                   if tag['Key'] == 'Name' and tag['Value']]:
+                        filtered.append(i)
+            instances = filtered
 
         # Iterate through found instances and filter based on exclude options
         for opt in Application._OPTS:
@@ -197,10 +202,10 @@ class Application(krux_ec2.cli.Application):
             for opt_value in opt_values:
                 # Exclude instances if they have an attribute that is excluded
                 instances = [
-                                i for i in instances
-                                if Application._INSTANCE_ATTR[opt](i, opt_value) is None or
-                                opt_value not in Application._INSTANCE_ATTR[opt](i, opt_value)
-                            ]
+                    i for i in instances
+                    if hasattr(i, opt_value) and (Application._INSTANCE_ATTR[opt](i, opt_value) is None or
+                        opt_value not in Application._INSTANCE_ATTR[opt](i, opt_value))
+                ]
 
         return instances
 

--- a/aws_analysis_tools/cli/instances.py
+++ b/aws_analysis_tools/cli/instances.py
@@ -185,6 +185,8 @@ class Application(krux_ec2.cli.Application):
             )
             filtered = []
             for i in instances:
+                # Include instances which have tags (not terminated) and
+                # which don't have a value for the Name tag
                 if i.tags and not [tag for tag in i.tags
                                    if tag['Key'] == 'Name' and tag['Value']]:
                         filtered.append(i)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION      = '0.6.5'
+VERSION      = '0.6.6'
 
 # URL to the repository on Github.
 REPO_URL     = 'https://github.com/krux/aws-analysis-tools'


### PR DESCRIPTION
## Why are we adding or upgrading this package?

_The boto3 library returns an ec2.Instance object with a different layout, leading to NoneType exceptions from the chronos script zombie_instances.sh_

## Who will be affected by this change?

_PE_

## What gif best describes this package or how it makes you feel?

![cleanup](https://previews.123rf.com/images/lenm/lenm1707/lenm170700198/81936874-illustration-of-stickman-kids-with-their-teacher-doing-coastal-clean-up.jpg)

## Completion checklist

- [x] The pull request has been appropriately labeled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [x] Local `./fpm-cook.sh new-package-name` completes successfully
